### PR TITLE
Avoid truncating playback when CAE stop timers expire

### DIFF
--- a/cae/driver_alsa.cpp
+++ b/cae/driver_alsa.cpp
@@ -889,8 +889,12 @@ bool DriverAlsa::playbackPosition(int card,int stream,unsigned pos)
 
   if(alsa_playing[card][stream]) {
     alsa_stop_timer[card][stream]->stop();
-    alsa_stop_timer[card][stream]->
-      start(alsa_play_wave[card][stream]->getExtTimeLength()-pos);
+    int remaining_msec=
+      static_cast<int>(alsa_play_wave[card][stream]->getExtTimeLength())-
+      static_cast<int>(pos);
+    if(remaining_msec>0) {
+      alsa_stop_timer[card][stream]->start(remaining_msec);
+    }
   }
   return true;
 #else
@@ -1381,7 +1385,11 @@ void DriverAlsa::stopTimerData(int cardstream)
   int card=cardstream/RD_MAX_STREAMS;
   int stream=cardstream-card*RD_MAX_STREAMS;
 
-  stopPlayback(card,stream);
+  if((alsa_play_ring[card][stream]==NULL)||(!alsa_playing[card][stream])) {
+    return;
+  }
+  alsa_stop_timer[card][stream]->stop();
+  alsa_eof[card][stream]=true;
 #endif  // ALSA
 }
 
@@ -1847,6 +1855,9 @@ void DriverAlsa::FillAlsaOutputStream(int card,int stream)
   double ratio=0.0;
   int free=(alsa_play_ring[card][stream]->writeSpace()-1);
   if(free<=0) {
+    return;
+  }
+  if(alsa_eof[card][stream]) {
     return;
   }
   ratio=(double)alsa_play_format[card].sample_rate/

--- a/cae/driver_jack.cpp
+++ b/cae/driver_jack.cpp
@@ -844,8 +844,12 @@ bool DriverJack::playbackPosition(int card,int stream,unsigned pos)
 
   if(jack_playing[stream]) {
     jack_stop_timer[stream]->stop();
-    jack_stop_timer[stream]->
-      start(jack_play_wave[stream]->getExtTimeLength()-pos);
+    int remaining_msec=
+      static_cast<int>(jack_play_wave[stream]->getExtTimeLength())-
+      static_cast<int>(pos);
+    if(remaining_msec>0) {
+      jack_stop_timer[stream]->start(remaining_msec);
+    }
   }
   return true;
 #else
@@ -1369,8 +1373,14 @@ void DriverJack::processBuffers()
 void DriverJack::stopTimerData(int stream)
 {
 #ifdef JACK
-  stopPlayback(jack_card,stream);
-  //  statePlayUpdate(jack_card,stream,2);
+  if((stream<0)||(stream>=RD_MAX_STREAMS)) {
+    return;
+  }
+  if(!jack_playing[stream]) {
+    return;
+  }
+  jack_stop_timer[stream]->stop();
+  jack_eof[stream]=true;
 #endif  // JACK
 }
 


### PR DESCRIPTION
## Summary
- stop ALSA/JACK timer expirations from calling stopPlayback so queued audio can drain cleanly
- add guardrails around playback timer restarts and ALSA buffer filling to avoid underflow and stale reads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2ec54bb5083308e47b010ae1c2ea6